### PR TITLE
Add default root password to postgres service definition

### DIFF
--- a/docker-compose-env.yml
+++ b/docker-compose-env.yml
@@ -36,6 +36,8 @@ services:
 
   postgresql:
     image: postgres:9.6-alpine
+    environment:
+      - POSTGRES_PASSWORD=root 
     volumes:
       - ./configuration/postgresql/initdb:/docker-entrypoint-initdb.d
       - postgresqldata:/var/lib/postgresql/data

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,6 +27,8 @@ services:
 
   postgresql:
     image: postgres:9.6-alpine
+    environment:
+      - POSTGRES_PASSWORD=root
     volumes:
       - ./configuration/postgresql/initdb:/docker-entrypoint-initdb.d
       - postgresqldata:/var/lib/postgresql/data


### PR DESCRIPTION
Thanks for preparing the whole stack on docker-compose. It's really easy to use.
 
After `docker-compose up -d`, the _postgres_ service is down and `docker logs` prints information about missing root password.

```bash
postgresql_1 | Error: Database is uninitialized and superuser password is not specified.
postgresql_1 |        You must specify POSTGRES_PASSWORD to a non-empty value for the
postgresql_1 |        superuser. For example, "-e POSTGRES_PASSWORD=password" on "docker run".
postgresql_1 |
postgresql_1 |        You may also use "POSTGRES_HOST_AUTH_METHOD=trust" to allow all
postgresql_1 |        connections without a password. This is *not* recommended.
postgresql_1 |
postgresql_1 |        See PostgreSQL documentation about "trust":
postgresql_1 |        https://www.postgresql.org/docs/current/auth-trust.html
```

Since these docker-compose files are for testing purposes, I think it's OK to use some default root password. It'll make the `up` process seamlessly.

Kind Regards.