### PR TITLE
MQTT authentication for gateway

### DIFF
--- a/configuration/chirpstack-application-server/chirpstack-application-server.toml
+++ b/configuration/chirpstack-application-server/chirpstack-application-server.toml
@@ -9,6 +9,8 @@ url="redis://redis:6379"
 
 [application_server.integration.mqtt]
 server="tcp://mosquitto:1883"
+username="chirpstack_as"
+password="chirpstack_as"
 
 [application_server.api]
 public_host="chirpstack-application-server:8001"

--- a/configuration/chirpstack-gateway-bridge/chirpstack-gateway-bridge.toml
+++ b/configuration/chirpstack-gateway-bridge/chirpstack-gateway-bridge.toml
@@ -3,5 +3,5 @@
 
 [integration.mqtt.auth.generic]
 servers=["tcp://mosquitto:1883"]
-username=""
-password=""
+username="chirpstack_gw"
+password="chirpstack_gw"

--- a/configuration/chirpstack-network-server/chirpstack-network-server.toml
+++ b/configuration/chirpstack-network-server/chirpstack-network-server.toml
@@ -45,6 +45,8 @@ name="EU_863_870"
 
 [network_server.gateway.backend.mqtt]
 server="tcp://mosquitto:1883"
+username="chirpstack_ns"
+password="chirpstack_ns"
 
 [join_server.default]
 server="http://chirpstack-application-server:8003"

--- a/configuration/mosquitto/acls
+++ b/configuration/mosquitto/acls
@@ -1,0 +1,16 @@
+user chirpstack_gw
+topic write gateway/+/event/+
+topic read gateway/+/command/+
+
+user chirpstack_ns
+topic read gateway/+/event/+
+topic write gateway/+/command/+
+
+user chirpstack_as
+topic write application/+/device/+/rx
+topic write application/+/device/+/join
+topic write application/+/device/+/ack
+topic write application/+/device/+/error
+topic read application/+/device/+/tx
+topic write application/+/device/+/status
+topic write application/+/device/+/location

--- a/configuration/mosquitto/mosquitto.conf
+++ b/configuration/mosquitto/mosquitto.conf
@@ -1,0 +1,29 @@
+auth_plugin /mosquitto/go-auth.so
+auth_opt_backends files, postgres, jwt
+auth_opt_check_prefix false
+allow_anonymous false
+
+auth_opt_log_level debug
+auth_opt_password_path /etc/mosquitto/passwords
+auth_opt_acl_path /etc/mosquitto/acls
+auth_opt_cache true
+auth_opt_cache_reset true
+
+auth_opt_pg_host postgresql
+auth_opt_pg_dbname chirpstack_as
+auth_opt_pg_user chirpstack_as
+auth_opt_pg_password chirpstack_as
+#auth_opt_pg_userquery select mqtt_key_hash from gateway where name = $1 limit 1
+#auth_opt_pg_aclquery select distinct 'gateway/' || encode(mac, 'hex') || '/+' from gateway where name = $1 and $2 = $2
+
+auth_opt_pg_userquery select password_hash from "user" where username = $1 and is_active = true limit 1
+auth_opt_pg_superquery select count(*) from "user" where username = $1 and is_admin = true
+auth_opt_pg_aclquery select distinct 'application/' || a.id || '/#' from "user" u inner join organization_user ou on ou.user_id = u.id inner join organization o on o.id = ou.organization_id inner join application a on a.organization_id = o.id where u.username = $1 and $2 = $2
+
+auth_opt_jwt_remote false
+auth_opt_jwt_secret verysecret
+#auth_opt_jwt_db chirpstack_as
+auth_opt_jwt_userquery select count(*) from "user" where username = $1 and is_active = true limit 1
+#auth_opt_jwt_superquery select count(*) from "user" where username = $1 and is_admin = true
+#auth_opt_jwt_aclquery select distinct 'application/' || a.id || '/#' from "user" u inner join organization_user ou on ou.user_id = u.id inner join organization o on o.id = ou.organization_id inner join application a on a.organization_id = o.id where u.username = $1 and $2 = $2
+auth_opt_jwt_userfield Username

--- a/configuration/mosquitto/passwords
+++ b/configuration/mosquitto/passwords
@@ -1,0 +1,8 @@
+# Hash version of "chirpstack_gw", obtained with pw utility
+chirpstack_gw:PBKDF2$sha512$100000$Y7Yvp81tQYz5VAUsUw21Sw==$lt3sPQ8z77Rw6GvcBZ7+GFXuE31oI2aJHxiuoVfdjzGBs5OKFmDb0CqM8filkrkQrUUhu79IQw1mWUfAETpqqQ==
+
+# Hash version of "chirpstack_ns", obtained with pw utility
+chirpstack_ns:PBKDF2$sha512$100000$h8cP1J0jJYEfj3EYYIwWcw==$ZYfxrClxzp7NrXbEPoyfX7qMvBoSA9d9WKYfrQzTBB2+Atr9AU8L7NmVLQyNdC1ZfFGHdjRZqaEHH21l4PX9Ow==
+
+# Hash version of "chirpstack_as", obtained with pw utility
+chirpstack_as:PBKDF2$sha512$100000$G4JVSnlEvjtq3zXDg7jTug==$8lh1NbmgoPeNqXc8j1IN9uCkEnJIWUVW06nXhr6ve6o0okoXEiiM3UpIjalBfYuVlBGHVjNUX2tK0tVNzWImKA==

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -39,9 +39,11 @@ services:
       - redisdata:/data
 
   mosquitto:
-    image: eclipse-mosquitto
+    image: iegomez/mosquitto-go-auth:0.5.0
     ports:
       - 1883:1883
+    volumes:
+      - ./configuration/mosquitto:/etc/mosquitto 
 
 volumes:
   postgresqldata:


### PR DESCRIPTION
We integrated the Mosquitto-Go-Auth plugin from iegomez's work (here is their GitHub: https://github.com/iegomez/mosquitto-go-auth) to allow the MQTT authentication for gateways. This feature adds a new layer of security and the possibility to manage authorizations.

This pull request comes with two others, on [ChirpStack API](https://github.com/brocaar/chirpstack-api/pull/12) and [ChirpStack Application Server](https://github.com/brocaar/chirpstack-application-server/pull/442) repositories.