### PR TITLE
Add missing sub-bands for US915 configuration examples

### DIFF
--- a/configuration/chirpstack-network-server/examples/chirpstack-network-server.us915.0.toml
+++ b/configuration/chirpstack-network-server/examples/chirpstack-network-server.us915.0.toml
@@ -17,7 +17,7 @@ net_id="000000"
 name="US915"
 
   [network_server.network_settings]
-  enabled_uplink_channels=[0, 1, 2, 3, 4, 5, 6, 7]
+  enabled_uplink_channels=[0, 1, 2, 3, 4, 5, 6, 7, 64]
 
 [network_server.gateway.backend.mqtt]
 server="tcp://mosquitto:1883"

--- a/configuration/chirpstack-network-server/examples/chirpstack-network-server.us915.1.toml
+++ b/configuration/chirpstack-network-server/examples/chirpstack-network-server.us915.1.toml
@@ -19,7 +19,7 @@ net_id="000000"
 name="US915"
 
   [network_server.network_settings]
-  enabled_uplink_channels=[8, 9, 10, 11, 12, 13, 14, 15]
+  enabled_uplink_channels=[8, 9, 10, 11, 12, 13, 14, 15, 65]
 
 [network_server.gateway.backend.mqtt]
 server="tcp://mosquitto:1883"


### PR DESCRIPTION
Failure to specify corresponding bands in the 64-71 range leads to broken
sub-band configuration and inability of client devices to transmit.

Fixes issue #42 .