### PR TITLE
Removed geolocation-server config reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,6 @@ but keep in mind that for production usage it might need modifications.
     * https://www.chirpstack.io/gateway-bridge/install/config/
     * https://www.chirpstack.io/network-server/install/config/
     * https://www.chirpstack.io/application-server/install/config/
-    * https://www.chirpstack.io/geolocation-server/install/config/
 * `configuration/postgresql/initdb/`: directory containing PostgreSQL initialization scripts
 
 ## Configuration


### PR DESCRIPTION
Just a line in the documentation that was left from before removing geolocation-server